### PR TITLE
Prompt block generation +  `AGENTS.md` file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ pnyx-lm-taxonomies/
 │   ├── pnyx_categories_v2.tax
 │   ├── pnyx_leaderboard_v3.tax
 │   └── README.md           # Taxonomy format guide with examples
+├── tests/                  # Test suite
+│   └── test_taxonomy_prompt.py  # Tests for prompt block functions
 ├── pyproject.toml          # Project configuration (uv managed)
 ├── README.md               # User-facing documentation
 └── AGENTS.md              # This file
@@ -130,6 +132,24 @@ Core utilities for taxonomy manipulation, analysis, and evaluation.
 - `get_model_graph(taxonomy_graph, samples_dict, target_model) -> nx.DiGraph`
   - Generates graph for specific model performance
   - Useful for model-specific analysis
+
+- `get_taxonomy_node_prompt_blocks(taxonomy_graph: nx.DiGraph, replace_underscores: bool = False) -> dict`
+  - Returns a dict mapping node name to its formatted prompt block string (excluding `root_c`)
+  - Each block follows `NODE_DESCRIPTION_TEMPLATE` with SKILL, DESCRIPTION, REQUIRES, and ENABLES sections
+  - REQUIRES: immediate predecessor nodes (advanced dependencies, excluding `root_c`)
+  - ENABLES: immediate successor nodes (basic skills); empty if only child is `root_c`
+  - `replace_underscores=True` replaces `_` with spaces in node names for more natural display
+
+- `get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph: nx.DiGraph, direction: str = "bottom-up", replace_underscores: bool = False) -> str`
+  - Returns all node prompt blocks concatenated in hierarchical order, separated by `\n---\n`
+  - `direction="top-down"`: advanced nodes first (ascending depth, root-adjacent first)
+  - `direction="bottom-up"`: basic nodes first (descending depth, leaves first)
+  - Uses longest-path depth from base nodes for correct topological ordering
+  - Supports `replace_underscores` flag for spaced node names
+
+- `NODE_DESCRIPTION_TEMPLATE`
+  - Module-level constant defining the string template for node prompt blocks
+  - Placeholders: `{name}`, `{description}`, `{requires}`, `{enables}`
 
 **Dataset Handling:**
 - Loads from `config/models.json`: Model metadata required for filtering and categorization

--- a/lm_taxonomies/utils.py
+++ b/lm_taxonomies/utils.py
@@ -11,6 +11,17 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 # Only initialized if needed
 models_config = None
 
+NODE_DESCRIPTION_TEMPLATE = """SKILL: {name}
+
+DESCRIPTION:
+{description}
+
+REQUIRES:
+{requires}
+
+ENABLES:
+{enables}"""
+
 
 def load_taxonomy(
     file_path: str,
@@ -403,3 +414,107 @@ def get_model_graph(taxonomy_graph, samples_dict, target_model):
     nx.set_node_attributes(model_graph, attributes, "scores")
 
     return model_graph
+
+
+def get_taxonomy_node_prompt_blocks(
+    taxonomy_graph: nx.classes.digraph.DiGraph,
+    replace_underscores: bool = False,
+) -> dict:
+    """
+    Returns a dict mapping node name to its formatted prompt block string
+    (excluding root_c). Each block follows the NODE_DESCRIPTION_TEMPLATE
+    with SKILL, DESCRIPTION, REQUIRES, and ENABLES sections.
+
+    Parameters
+    ----------
+    taxonomy_graph : nx.DiGraph
+        The taxonomy graph.
+    replace_underscores : bool
+        If True, replaces underscores with spaces in node names for a
+        more natural display.
+    """
+    descriptions = get_taxonomy_description(taxonomy_graph)
+
+    node_map = {}
+    for node in taxonomy_graph.nodes:
+        if node == "root_c":
+            continue
+
+        name = node.replace("_", " ") if replace_underscores else node
+        description = descriptions.get(node, "")
+
+        requires = [p for p in taxonomy_graph.predecessors(node) if p != "root_c"]
+        requires_str = "\n".join(f"- {p}" for p in requires) if requires else ""
+
+        enables = list(taxonomy_graph.successors(node))
+        # If the only "child" is root_c, leave enables empty
+        if len(enables) == 1 and "root_c" in enables:
+            enables_str = ""
+        else:
+            enables_str = "\n".join(f"- {s}" for s in enables) if enables else ""
+
+        block = NODE_DESCRIPTION_TEMPLATE.format(
+            name=name,
+            description=description,
+            requires=requires_str,
+            enables=enables_str,
+        )
+        node_map[node] = block
+
+    return node_map
+
+
+def get_taxonomy_hierarchy_prompt_blocks(
+    taxonomy_graph: nx.classes.digraph.DiGraph,
+    direction: str = "bottom-up",
+    replace_underscores: bool = False,
+) -> str:
+    """
+    Returns all node prompt blocks concatenated in hierarchical order,
+    separated by '---'.
+
+    Parameters
+    ----------
+    taxonomy_graph : nx.DiGraph
+        The taxonomy graph.
+    direction : str
+        "bottom-up" sorts by depth descending (leaves/base nodes first).
+        "top-down" sorts by depth ascending (root-adjacent nodes first).
+    replace_underscores : bool
+        If True, replaces underscores with spaces in node names.
+
+    Returns
+    -------
+    str
+        All prompt blocks concatenated.
+    """
+    node_map = get_taxonomy_node_prompt_blocks(taxonomy_graph, replace_underscores)
+
+    # Compute depth for each node in topological order
+    # Depth = longest path from a base node (no predecessors)
+    depths = {}
+    for node in nx.topological_sort(taxonomy_graph):
+        if node == "root_c":
+            continue
+        if node not in node_map:
+            continue
+        predecessors = list(taxonomy_graph.predecessors(node))
+        if not predecessors:
+            depths[node] = 0
+        else:
+            max_pred_depth = max(depths.get(p, 0) for p in predecessors)
+            depths[node] = max_pred_depth + 1
+
+    # Sort nodes by depth
+    # Top-down = advanced first (ascending depth: 0, 1, 2, ...)
+    # Bottom-up = basic first (descending depth: ..., 2, 1, 0)
+    reverse = direction == "bottom-up"
+    sorted_nodes = sorted(
+        [n for n in depths if n in node_map],
+        key=lambda n: depths[n],
+        reverse=reverse,
+    )
+
+    # Concatenate blocks in sorted order
+    ordered_blocks = [node_map[n] for n in sorted_nodes]
+    return "\n---\n".join(ordered_blocks)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["ipykernel"]
+dev = ["ipykernel", "pytest"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["lm_taxonomies"]
@@ -32,3 +32,8 @@ lm_taxonomies = ["lm_taxonomies/config/*.json"]
 
 [tool.ruff]
 include = ["lm_taxonomies/**/*.py", "scripts/**/*.py"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/tests/test_taxonomy_prompt.py
+++ b/tests/test_taxonomy_prompt.py
@@ -1,0 +1,146 @@
+import pytest
+import networkx as nx
+
+from lm_taxonomies.utils import (
+    load_taxonomy,
+    get_taxonomy_node_prompt_blocks,
+    get_taxonomy_hierarchy_prompt_blocks,
+    NODE_DESCRIPTION_TEMPLATE,
+)
+
+TAXONOMY_PATH = "taxonomies/general_skills_v2-1-full.tax"
+
+
+@pytest.fixture
+def taxonomy_graph():
+    return load_taxonomy(TAXONOMY_PATH)
+
+
+class TestGetTaxonomyNodePromptBlocks:
+    def test_returns_dict(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        assert isinstance(result, dict)
+
+    def test_excludes_root_c(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        assert "root_c" not in result
+
+    def test_contains_all_nodes(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        expected_nodes = [n for n in taxonomy_graph.nodes if n != "root_c"]
+        assert len(result) == len(expected_nodes)
+        for node in expected_nodes:
+            assert node in result
+
+    def test_block_format(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        sample_key = list(result.keys())[0]
+        block = result[sample_key]
+        assert "SKILL:" in block
+        assert "DESCRIPTION:" in block
+        assert "REQUIRES:" in block
+        assert "ENABLES:" in block
+
+    def test_replaces_underscores(self, taxonomy_graph):
+        result_original = get_taxonomy_node_prompt_blocks(taxonomy_graph, replace_underscores=False)
+        result_replaced = get_taxonomy_node_prompt_blocks(taxonomy_graph, replace_underscores=True)
+
+        # Dict keys should remain the same
+        assert list(result_original.keys()) == list(result_replaced.keys())
+
+        # Find a node with underscores
+        node_with_underscore = [n for n in result_original.keys() if "_" in n][0]
+        assert "_" in result_original[node_with_underscore].split("SKILL:")[1].split("\n")[0]
+        assert " " in result_replaced[node_with_underscore].split("SKILL:")[1].split("\n")[0]
+        assert "_" not in result_replaced[node_with_underscore].split("SKILL:")[1].split("\n")[0]
+
+    def test_no_underscores_when_replaced(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph, replace_underscores=True)
+        for block in result.values():
+            assert "_" not in block.split("SKILL:")[1].split("\n")[0]
+
+    def test_root_c_only_child_empty_enables(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        for node in taxonomy_graph.nodes:
+            if node == "root_c":
+                continue
+            successors = list(taxonomy_graph.successors(node))
+            if len(successors) == 1 and "root_c" in successors:
+                block = result[node]
+                enables_section = block.split("ENABLES:")[1].split("\n")[0].strip()
+                assert enables_section == ""
+
+    def test_requires_excludes_root_c(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        for block in result.values():
+            requires_section = block.split("REQUIRES:")[1].split("ENABLES:")[0]
+            assert "root_c" not in requires_section
+
+    def test_block_uses_template(self, taxonomy_graph):
+        result = get_taxonomy_node_prompt_blocks(taxonomy_graph)
+        sample_key = list(result.keys())[0]
+        block = result[sample_key]
+        template_lines = NODE_DESCRIPTION_TEMPLATE.split("\n")
+        assert block.startswith(f"SKILL:")
+        assert "\nDESCRIPTION:\n" in block
+        assert "\nREQUIRES:\n" in block
+        assert "\nENABLES:" in block
+
+
+class TestGetTaxonomyHierarchyPromptBlocks:
+    def test_returns_string(self, taxonomy_graph):
+        result = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph)
+        assert isinstance(result, str)
+
+    def test_contains_separators(self, taxonomy_graph):
+        result = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph)
+        separator = "\n---\n"
+        assert separator in result
+
+    def test_contains_all_blocks(self, taxonomy_graph):
+        result = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph)
+        block_count = len(result.split("\n---\n"))
+        expected_count = sum(1 for n in taxonomy_graph.nodes if n != "root_c")
+        assert block_count == expected_count
+
+    def test_top_down_ordering(self, taxonomy_graph):
+        result = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph, direction="top-down")
+        blocks = result.split("\n---\n")
+        first_block = blocks[0]
+        first_skill = first_block.split("\n")[0].replace("SKILL: ", "")
+        # First block should be adjacent to root_c (depth 1)
+        preds = list(taxonomy_graph.predecessors(first_skill))
+        assert preds == ["root_c"] or (len(preds) == 0 and first_skill == taxonomy_graph.nodes.__iter__().__next__())
+
+    def test_bottom_up_ordering(self, taxonomy_graph):
+        result = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph, direction="bottom-up")
+        blocks = result.split("\n---\n")
+        last_block = blocks[-1]
+        last_skill = last_block.split("\n")[0].replace("SKILL: ", "")
+        # Last block should be a shallow node (depth 1, adjacent to root_c)
+        preds = [p for p in taxonomy_graph.predecessors(last_skill) if p != "root_c"]
+        assert len(preds) == 0  # No non-root_c predecessors = depth 1
+
+    def test_replaces_underscores_in_hierarchy(self, taxonomy_graph):
+        result_original = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph, replace_underscores=False)
+        result_replaced = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph, replace_underscores=True)
+
+        # Original should have underscores
+        assert "_" in result_original
+
+        # Replaced should have spaces instead
+        for block in result_replaced.split("\n---\n"):
+            skill_line = block.split("\n")[0]
+            assert "_" not in skill_line
+
+    def test_default_direction_is_bottom_up(self, taxonomy_graph):
+        result_default = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph)
+        result_explicit = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph, direction="bottom-up")
+        assert result_default == result_explicit
+
+    def test_contains_skill_names(self, taxonomy_graph):
+        result = get_taxonomy_hierarchy_prompt_blocks(taxonomy_graph)
+        for node in taxonomy_graph.nodes:
+            if node == "root_c":
+                continue
+            assert f"SKILL: {node}" in result

--- a/uv.lock
+++ b/uv.lock
@@ -303,6 +303,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -569,6 +578,12 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pytest" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -579,10 +594,14 @@ requires-dist = [
     { name = "numpy", specifier = "==2.2" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "pygraphviz", specifier = ">=1.14" },
+    { name = "pytest", marker = "extra == 'dev'" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "tqdm", specifier = ">=4.67.3" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "matplotlib"
@@ -980,6 +999,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1068,6 +1096,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add prompt block generation utilities

## Summary

Adds two functions and a template constant to `utils.py` for generating formatted prompt blocks from taxonomy graphs, plus a 17-test suite.

## `lm_taxonomies/utils.py`

- **`NODE_DESCRIPTION_TEMPLATE`** — String template (`{name}`, `{description}`, `{requires}`, `{enables}`)
- **`get_taxonomy_node_prompt_blocks(graph, replace_underscores=False) -> dict`** — Node name → formatted block dict (excludes `root_c`)
- **`get_taxonomy_hierarchy_prompt_blocks(graph, direction="bottom-up", replace_underscores=False) -> str`** — All blocks concatenated by `\n---\n` in hierarchical order (`top-down` / `bottom-up`)

## Others
- `AGENTS.md` — documentation update
- Test for the taxonomy prompt.

## Test

```bash
uv run pytest tests/test_taxonomy_prompt.py -v